### PR TITLE
docs: Doctest cleanup

### DIFF
--- a/docs/src/examples/jwst.md
+++ b/docs/src/examples/jwst.md
@@ -9,13 +9,13 @@ In this example, we show how to use ASDF.jl to load and view some astronomical d
 
 ## Load
 
-```@repl jwst
+```@example jwst
 
 fpath = let
     data_dir = joinpath("..", "..", "data")
     mkpath(data_dir)
     joinpath(data_dir, "jwst.asdf")
-end;
+end
 
 if !isfile(fpath)
     using Downloads: download
@@ -24,7 +24,7 @@ if !isfile(fpath)
 end
 ```
 
-```@repl jwst
+```@example jwst
 using ASDF
 
 af = load(fpath; extensions = true)

--- a/docs/src/examples/roman.md
+++ b/docs/src/examples/roman.md
@@ -9,12 +9,12 @@ In this example, we show how to use ASDF.jl to load and view some simulated astr
 
 ## Load
 
-```@repl roman
+```@example roman
 fpath = let
     data_dir = joinpath("..", "..", "data")
     mkpath(data_dir)
     joinpath(data_dir, "roman.asdf")
-end;
+end
 
 if !isfile(fpath)
     using AWSS3, AWS
@@ -31,7 +31,7 @@ if !isfile(fpath)
 end
 ```
 
-```@repl roman
+```@example roman
 using ASDF
 
 af = load(fpath; extensions = true, validate_checksum = false)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,9 +2,7 @@
 
 A new [Advanced Scientific Data Format (ASDF)](https://asdf-standard.readthedocs.io/en/latest/index.html) package, written in Julia.
 
-
 ## Quickstart
-
 
 ### Installation
 
@@ -14,7 +12,7 @@ pkg> add ASDF, OrderedCollections
 
 ### Usage
 
-```@repl
+```@example quickstart
 using ASDF, OrderedCollections
 
 doc = OrderedDict(
@@ -24,11 +22,15 @@ doc = OrderedDict(
         "field_3a" => ["apple", "orange", "pear"],
         "field_3b" => [1.0, 2.0, 3.0],
     )
-);
+)
 
 save("example.asdf", doc)
+```
 
+```@example quickstart
 af = load("example.asdf")
+```
 
+```@example quickstart
 ASDF.info(af; max_rows = 3)
 ```

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -12,165 +12,69 @@ The ASDF file format targets a similar audience as the [HDF5](https://www.hdfgro
 
 ASDF files are initially created as a dictionary with arbitrarily nested data:
 
-```jldoctest intro
-julia> using OrderedCollections
+```@example intro
+using OrderedCollections
 
-julia> af_payload = OrderedDict("field_1" => [5, 6, 7, 8], "field_2" => ["up", "down", "left", "right"], "field_3" => OrderedDict("field_3a" => ["apple", "orange", "pear"], "field_3b" => [1.0, 2.0, 3.0]));
+af_payload = OrderedDict("field_1" => [5, 6, 7, 8], "field_2" => ["up", "down", "left", "right"], "field_3" => OrderedDict("field_3a" => ["apple", "orange", "pear"], "field_3b" => [1.0, 2.0, 3.0]))
 ```
 
 !!! note
-    We use an `OrderedDict` from [OrderedCollections.jl](https://github.com/JuliaCollections/OrderedCollections.jl) to preserve the order of data on write and load, and to maximize compatibility with YAML.jl. For a potential alternative using [Dictionaries.jl](https://github.com/andyferris/Dictionaries.jl), see this [experimental branch](https://github.com/JuliaAstro/ASDF.jl/tree/dictionaries).
+    We use an `OrderedDict` from [OrderedCollections.jl](https://github.com/JuliaCollections/OrderedCollections.jl) to preserve the order of data on write and load, and to maximize compatibility with YAML.jl.
 
 ASDF.jl is registered with [FileIO.jl](https://juliaio.github.io/FileIO.jl/stable/), so this data can be written to the ASDF file format with the generic [`save`](@ref) function:
 
-```jldoctest intro
-julia> using ASDF
+```@example intro
+using ASDF
 
-julia> save("intro.asdf", af_payload)
+save("intro.asdf", af_payload)
 ```
 
 The saved file contains the following human-readable contents:
 
 !!! details "View file"
-    ```jldoctest intro
-    julia> read("intro.asdf", String) |> print
-    #ASDF 1.0.0
-    #ASDF_STANDARD 1.6.0
-    # This is an ASDF file <https://asdf-standard.readthedocs.io/>
-    %YAML 1.1
-    %TAG ! tag:stsci.edu:asdf/
-    ---
-    !core/asdf-1.1.0
-    field_1:
-      - 5
-      - 6
-      - 7
-      - 8
-    field_2:
-      - "up"
-      - "down"
-      - "left"
-      - "right"
-    field_3:
-      field_3a:
-        - "apple"
-        - "orange"
-        - "pear"
-      field_3b:
-        - 1.0
-        - 2.0
-        - 3.0
-    asdf_library: !core/software-1.0.0
-      name: "ASDF.jl"
-      author: "Erik Schnetter <schnetter@gmail.com>"
-      homepage: "https://github.com/JuliaAstro/ASDF.jl"
-      version: "2.0.0"
-    ...
+    ```@example intro
+    read("intro.asdf", String) |> print
     ```
 
 which can be loaded back with FileIO.jl's generic [`load`](@ref) function:
 
-```jldoctest intro
-julia> af = load("intro.asdf")
-intro.asdf
-├─ field_1::Vector{Int64} | shape = (4,)
-├─ field_2::Vector{String} | shape = (4,)
-├─ field_3::OrderedDict
-│  ├─ field_3a::Vector{String} | shape = (3,)
-│  └─ field_3b::Vector{Float64} | shape = (3,)
-└─ asdf_library::TaggedMapping
-   ├─ name::String | ASDF.jl
-   ├─ author::String | Erik Schnetter <schnetter@gmail.com>
-   ├─ homepage::String | https://github.com/JuliaAstro/ASDF.jl
-   └─ version::String | 2.0.0
+```@example intro
+af = load("intro.asdf")
 ```
 
 This is stored as an [`ASDF.ASDFFile`](@ref). To change the number of rows shown, pass this object to [`ASDF.info`](@ref):
 
-```jldoctest intro
-julia> ASDF.info(af; max_rows = 3)
-intro.asdf
-├─ field_1::Vector{Int64} | shape = (4,)
-├─ field_2::Vector{String} | shape = (4,)
-  ⋮  (8) more rows
+```@example intro
+ASDF.info(af; max_rows = 3)
 ```
 
 It contains a `metadata` field, which is a new dictionary that merges information about this library (stored under the `asdf_library` key) with the original user-defined `af_payload` dictionary. For convenience, `af.metadata[<key>]` can be accessed directly as `af[key]`. Since the underlying data is a dictionary, it can be modified in the standard way:
 
-```jldoctest intro
-julia> af["field_1"] = [50, 60, 70, 80];
-
-julia> af["field_1"]
-4-element Vector{Int64}:
- 50
- 60
- 70
- 80
+```@example intro
+af["field_1"] = [50, 60, 70, 80]
 ```
 
 The convenience syntax can also be used to save the modified `ASDF.ASDFFile` object directly:
 
-```jldoctest intro
-julia> save("intro_modified.asdf", af)
+```@example intro
+save("intro_modified.asdf", af)
 ```
 
 !!! details "View file"
-    ```jldoctest intro
-    julia> read("intro_modified.asdf", String) |> print
-    #ASDF 1.0.0
-    #ASDF_STANDARD 1.6.0
-    # This is an ASDF file <https://asdf-standard.readthedocs.io/>
-    %YAML 1.1
-    %TAG ! tag:stsci.edu:asdf/
-    ---
-    !core/asdf-1.1.0
-    field_1:
-      - 50
-      - 60
-      - 70
-      - 80
-    field_2:
-      - "up"
-      - "down"
-      - "left"
-      - "right"
-    field_3:
-      field_3a:
-        - "apple"
-        - "orange"
-        - "pear"
-      field_3b:
-        - 1.0
-        - 2.0
-        - 3.0
-    asdf_library: !core/software-1.0.0
-      name: "ASDF.jl"
-      author: "Erik Schnetter <schnetter@gmail.com>"
-      homepage: "https://github.com/JuliaAstro/ASDF.jl"
-      version: "2.0.0"
-    ...
+    ```@example intro
+    read("intro_modified.asdf", String) |> print
     ```
 
 ## Array storage
 
 By default, array data is written inline as a literal to the ASDF file. This can be stored and later accessed more efficiently by wrapping your data in an [`ASDF.NDArrayWrapper`](@ref). This allows for your data to be stored as a binary via the `inline = false` keyword (default), which can be further optimized by specifying a supported [compression algorithm](@ref ASDF.Compression) to use via the `compression` keyword:
 
-```jldoctest intro
-julia> af_payload = OrderedDict("meta" => OrderedDict("my" => OrderedDict("nested" => "metadata")), "data" => ASDF.NDArrayWrapper([1, 2, 3, 4]; compression = ASDF.C_Bzip2));
+```@example intro
+af_payload = OrderedDict("meta" => OrderedDict("my" => OrderedDict("nested" => "metadata")), "data" => ASDF.NDArrayWrapper([1, 2, 3, 4]; compression = ASDF.C_Bzip2))
 
-julia> save("intro_compressed.asdf", af_payload)
+save("intro_compressed.asdf", af_payload)
 
-julia> af = load("intro_compressed.asdf")
-intro_compressed.asdf
-├─ meta::OrderedDict
-│  └─ my::OrderedDict
-│     └─ nested::String | metadata
-├─ data::NDArray | shape = [4], datatype = Int64
-└─ asdf_library::TaggedMapping
-   ├─ name::String | ASDF.jl
-   ├─ author::String | Erik Schnetter <schnetter@gmail.com>
-   ├─ homepage::String | https://github.com/JuliaAstro/ASDF.jl
-   └─ version::String | 2.0.0
+af = load("intro_compressed.asdf")
 ```
 
 !!! details "View file"
@@ -207,9 +111,8 @@ intro_compressed.asdf
 
 Using `NDArrayWrapper` allows for the wrapped data to be lazily accessed as a strided view. To access the underlying data, use the `[]` (dereference) syntax:
 
-```jldoctest intro
-julia> af["data"][] == [1, 2, 3, 4]
-true
+```@example intro
+af["data"][] == [1, 2, 3, 4]
 ```
 
 ## Tagged objects

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -555,7 +555,7 @@ asdf_datatype_yaml(dt::Ucs4Datatype) = ["ucs4", dt.length]
 A single named field within a [`StructuredDatatype`](@ref). Corresponds to one entry in the ASDF `datatype` list when it takes the dict form:
 
 ```yaml
-- {name: x, datatype: float32, byteorder: little}
+- {name: x,     datatype: float32,    byteorder: little}
 - {name: label, datatype: [ascii, 8], byteorder: little}
 ```
 
@@ -575,9 +575,9 @@ An ASDF compound datatype consisting of named fields, corresponding to the list-
 
 ```yaml
 datatype:
-- {name: x,      datatype: float32, byteorder: little}
-- {name: y,      datatype: float32, byteorder: little}
-- {name: label,  datatype: [ascii, 4], byteorder: little}
+- {name: x,     datatype: float32,    byteorder: little}
+- {name: y,     datatype: float32,    byteorder: little}
+- {name: label, datatype: [ascii, 4], byteorder: little}
 ```
 
 The corresponding Julia type (returned by `Base.Type`) is a `NamedTuple` with one field per entry, e.g., `@NamedTuple{x::Float32, y::Float32, label::NTuple{4,UInt8}}`. This type is `isbitstype`, so `reinterpret`, `sizeof`, and `bswap` all work correctly on it.

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -863,7 +863,7 @@ function Base.getindex(ndarray::NDArray)
     else
         # Unreachable branch. Caught in the constructor for `NDArray`. This branch would imply that
         # `ndarray` is in invalid state; neither `source` nor `data` is given.
-        @assert false
+        @assert false # COV_EXCL_LINE
     end
 
     # Check array layout

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,6 @@
 using ParallelTestRunner: runtests, find_tests, parse_args
 using ASDF
 
-# Doctest
-using Documenter
-DocMeta.setdocmeta!(ASDF, :DocTestSetup, :(using ASDF); recursive = true)
-doctest(ASDF)
-
 const init_code = quote
     using ASDF
     using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using ASDF
 
 const init_code = quote
     using ASDF
+    using OrderedCollections
     using Test
     using YAML
 

--- a/test/test-doctest.jl
+++ b/test/test-doctest.jl
@@ -1,0 +1,5 @@
+using Documenter
+
+DocMeta.setdocmeta!(ASDF, :DocTestSetup, :(using ASDF); recursive = true)
+
+doctest(ASDF)

--- a/test/test-read_fallbacks.jl
+++ b/test/test-read_fallbacks.jl
@@ -261,6 +261,19 @@ end
     @test tsc == "3.14"
 end
 
+@testset "convert `TaggedMapping` to `OrderedDict`" begin
+    # Dropping the tag back to an `OrderedDict` must preserve insertion order. Deliberately
+    # non-alphabetical keys so hash ordering would not match by coincidence.
+    tm = ASDF.TaggedMapping(
+        "tag:example.org:mylib/widget-1.0.0",
+        OrderedDict{Any, Any}("zebra" => 1, "apple" => 2, "mango" => 3),
+    )
+    od = convert(OrderedDict{Any, Any}, tm)
+    @test od isa OrderedDict{Any, Any}
+    @test collect(keys(od)) == ["zebra", "apple", "mango"]
+    @test od == tm.value
+end
+
 @testset "tagged node mutation" begin
     # The `Tagged*` containers delegate mutation to the wrapped value so a loaded node can be
     # edited in place while keeping its tag. Each mutating method is pinned down here; the

--- a/test/test-write.jl
+++ b/test/test-write.jl
@@ -125,7 +125,7 @@ end
     # deliberately non-alphabetical order so hash ordering would not match by coincidence.
     doc = ASDF.TaggedMapping(
         "tag:example.org:mylib/root-1.0.0",
-        ASDF.OrderedDict{Any, Any}("zebra" => 1, "apple" => 2, "mango" => 3),
+        OrderedDict{Any, Any}("zebra" => 1, "apple" => 2, "mango" => 3),
     )
 
     ASDF.write_file(path, doc)

--- a/test/test-write.jl
+++ b/test/test-write.jl
@@ -54,6 +54,24 @@ end
     @test result == "[ASDF file \"my_file.asdf\"]\nx: 1\n"
 end
 
+@testset "Mutate and re-save an `ASDFFile`" begin
+    dir = mktempdir(; cleanup = true)
+    orig = joinpath(dir, "orig.asdf")
+    resaved = joinpath(dir, "resaved.asdf")
+
+    save(orig, Dict{Any, Any}("x" => 1))
+    af = load(orig)
+    af["x"] = 2
+    af["y"] = "new"
+    @test af["x"] == 2
+
+    # `save` accepts the `ASDFFile` wrapper itself, unwrapping to its metadata tree.
+    save(resaved, af)
+    af′ = load(resaved)
+    @test af′["x"] == 2
+    @test af′["y"] == "new"
+end
+
 @testset "helper functions" begin
     @test ASDF.native2big_U8(0x05) == [0x05]
     @test ASDF.native2big_U8(5) == [0x05]


### PR DESCRIPTION
Replace `@repl` and `jldoctest` blocks with `@example` blocks in markdown prose