### PR TITLE
Only run workflow on push to specific branches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,7 @@
 name: CI
 on:
   push:
-    branches:
-      - 'main'
-      - 'release-'
+    branches: [main]
     tags: '*'
   pull_request:
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
 jobs:
   test:
     name: Julia ${{matrix.version}} - ${{matrix.os}} - ${{matrix.arch}} - ${{github.event_name}}

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -4,8 +4,7 @@ on:
     branches:
       - 'main'
       - 'release-'
-    tags:
-      - '*'
+    tags: '*'
   pull_request:
 jobs:
   runic:

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,9 +1,7 @@
 name: Runic.jl formatting
 on:
   push:
-    branches:
-      - 'main'
-      - 'release-'
+    branches: [main]
     tags: '*'
   pull_request:
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Documentation
-
 on:
   push:
     branches:
-    - main
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,7 @@
 name: Documentation
 on:
   push:
-    branches:
-      - 'main'
-      - 'release-'
+    branches: [main]
     tags: '*'
   pull_request:
 


### PR DESCRIPTION
Restrict workflows to run only on push to main, because `pull_request` already takes care of PRs and we end up with duplicate runs (e.g., https://github.com/JuliaAstro/ASDF.jl/actions/runs/29667197889 and https://github.com/JuliaAstro/ASDF.jl/actions/runs/29667230580).

Side note: is the `'release-'` specifier still needed? I copied it over from Format.yml, but we don't seem to have any branches under that name. I'm guessing it was for v2 release, but it doesn't seem to be a permanent fixture of the repo.